### PR TITLE
Fixes cancelOrders(all)

### DIFF
--- a/src/apis/deribit.js
+++ b/src/apis/deribit.js
@@ -301,6 +301,7 @@ class DeribitApi extends ApiInterface {
     activeOrders(symbol, side) {
         const params = {
             instrument: symbol.toUpperCase(),
+            type: 'any'
         };
 
         return this.makeAuthRequest('/api/v1/private/getopenorders', params)


### PR DESCRIPTION
Fixes #3 by adding missing parameter.
All order types are now returned.