### PR TITLE
This allows to click and copy to clipboard any command line from /list + displays keyboard

### DIFF
--- a/src/notifications/telegram.js
+++ b/src/notifications/telegram.js
@@ -1,5 +1,6 @@
 const config = require('config');
 const Telegraf = require('telegraf');
+const Markup = require('telegraf/markup')
 const logger = require('../common/logger').logger;
 
 
@@ -129,11 +130,19 @@ class TelegramNotifier {
         // Handle the /list command
         bot.command('list', async (ctx) => {
             if (this.isSafeUser(ctx.message.from.id)) {
-                this.lastChatId = ctx.message.chat.id;
                 logger.progress('Showing list of shortcuts in Telegram chat');
                 const shortcuts = config.get('telegram.shortcuts');
-                const msg = shortcuts.reduce((fullMsg, item) => `${fullMsg}\n\`${item.name}\` - ${item.message}`, 'Found the following shortcuts...');
-                ctx.replyWithMarkdown(msg);
+                const msg = shortcuts.reduce((fullMsg, item) => `${fullMsg}\n\`/shortcut ${item.name}\` - ${item.message}`, 'Found the following shortcuts...');
+                const cmds = []
+                shortcuts.forEach(function(element) {
+                  cmds.push('/shortcut '+element.name)
+                });
+                ctx.replyWithMarkdown(msg, Markup
+                  .keyboard(cmds)
+                  .oneTime()
+                  .resize()
+                  .extra()
+                )
             }
         });
 

--- a/src/notifications/telegram.js
+++ b/src/notifications/telegram.js
@@ -132,8 +132,8 @@ class TelegramNotifier {
                 this.lastChatId = ctx.message.chat.id;
                 logger.progress('Showing list of shortcuts in Telegram chat');
                 const shortcuts = config.get('telegram.shortcuts');
-                const msg = shortcuts.reduce((fullMsg, item) => `${fullMsg}\n*${item.name}* - ${item.message}`, 'Found the following shortcuts...');
-                ctx.reply(msg, {parse_mode: 'Markdown'});
+                const msg = shortcuts.reduce((fullMsg, item) => `${fullMsg}\n\`${item.name}\` - ${item.message}`, 'Found the following shortcuts...');
+                ctx.replyWithMarkdown(msg);
             }
         });
 


### PR DESCRIPTION
Change `/list` output from:

Found the following shortcuts...
**han** - han(BTC-PERPETUAL) { balance() }
**luke** - luke(BTC-PERPETUAL) { balance() }

To:

Found the following shortcuts...
`/shortcut han` - han(BTC-PERPETUAL) { balance() }
`/shortcut luke` - luke(BTC-PERPETUAL) { balance() }

A click on command name copies it to clipboard.
It also display options in keyboard.