### PR TITLE
Ping pong rounding

### DIFF
--- a/src/common/scaled_amounts.js
+++ b/src/common/scaled_amounts.js
@@ -14,6 +14,10 @@ module.exports = (orderCount, totalSpend, randomDiff, round) => {
         return [];
     }
 
+    if (orderCount < 2) {
+        return [totalSpend];
+    }
+
     // Create an array with a value of 1 for each order
     const sizes = Array(...Array(orderCount)).map(() => 1);
 

--- a/src/common/scaled_prices.js
+++ b/src/common/scaled_prices.js
@@ -17,6 +17,10 @@ module.exports = (orderCount, from, to, randomDiff = 0, easingFunction = 'linear
         return [];
     }
 
+    if (orderCount < 2) {
+        return [from];
+    }
+
     const range = to - from;
 
     // Create an array with a progress from 0 to 1


### PR DESCRIPTION
Updated so that scaled orders and ping pong orders can be created with an order count of zero or one. With zero, the obviously do nothing and with one they put everything at the from price.

There were also some improvements in calculating and rounding the order amount for ping pong orders esp. where the amount was provided using pingAmount and pongAmount.