### PR TITLE
Adding Deribit open positions call

### DIFF
--- a/src/exchanges/commands/open_positions.js
+++ b/src/exchanges/commands/open_positions.js
@@ -1,0 +1,21 @@
+const logger = require('../../common/logger').logger;
+const util = require('../../common/util');
+const notifier = require('../../notifications/notifier');
+
+/**
+ * Return Open Positions (Derebit Only)
+ */
+
+module.exports = (context) => {
+        const { ex = {}, symbol = '' } = context;
+        logger.progress('NOTIFY OPEN POSITIONS');
+
+        return ex.api.positions().then((res) => {
+            for (var i=0; i<res.length; i++){
+                const msg = `--------\nInstrument: ${res[i].instrument}\n` + `size: ${res[i].size}\n` + `avgPrice: ${util.roundDown(res[i].averagePrice)}\n`
+                            + `pnl: ${res[i].profitLoss}\n---------\n`;
+                notifier.send(msg);
+                logger.results(msg);
+            }
+});
+};

--- a/src/exchanges/exchange.js
+++ b/src/exchanges/exchange.js
@@ -17,6 +17,7 @@ const cancelOrders = require('./commands/cancel_orders');
 const notify = require('./commands/notify');
 const balance = require('./commands/balance');
 const wait = require('./commands/wait');
+const openPositions = require('./commands/open_positions');
 
 // and some support functions
 const scaledOrderSize = require('./support/scaled_order_size');
@@ -71,13 +72,14 @@ class Exchange {
             wait,
             notify,
             balance,
+	    openPositions,
         };
 
         this.commandWhiteList = [
             'icebergOrder', 'scaledOrder', 'twapOrder', 'pingPongOrder', 'marketMakerOrder',
             'steppedMarketOrder', 'accDisOrder',
             'limitOrder', 'marketOrder', 'stopMarketOrder',
-            'cancelOrders', 'wait', 'notify', 'balance'];
+            'cancelOrders', 'wait', 'notify', 'balance', 'openPositions'];
     }
 
     /**


### PR DESCRIPTION
Added support for Deribit open positions call which was already defined in api.js.

Example syntax: 
deribit(BTC-PERPETUAL) {openPositions();}